### PR TITLE
Add link for Proton guide

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -191,6 +191,11 @@
                     <h2> GECK Wiki </h2>
                 </a> Most comprehensive resource for the GECK and scripting.
             </p>
+            <p>
+                <a class="link" href="https://anfinitinetwork.com/fallout/moddinglinked">
+                    <h2> Proton Guide </h2>
+                </a> A supplemental guide for modding Bethesda games on GNU/Linux.
+            </p>
         </div>
         <div>
             <p>


### PR DESCRIPTION
The guide is generalized now, so this can be done for the other guides, if desired.