### PR TITLE
Ammo Script Fixes sidebar and perf guide link

### DIFF
--- a/bugfix.html
+++ b/bugfix.html
@@ -499,7 +499,7 @@
             <!-- Ammo Script Fixes -->
             <p>
                 <a class="link" href="https://www.nexusmods.com/newvegas/mods/63997" target="_blank">
-                    <h2 id="ammoScriptFix">Ammo Script Fixes</h2>
+                    <h2 id="ammoScriptFixes">Ammo Script Fixes</h2>
                 </a>
             </p>
             <h2 class="install">Installation instructions:</h2>
@@ -510,7 +510,7 @@
 
             <!-- Perf guide -->
             <p>
-                <a class="link" href="https://performance.moddinglinked.com" target="_blank">
+                <a class="link" href="https://performance.moddinglinked.com/falloutnv.html" target="_blank">
                     <h2 id="flip">Performance and Stability Guide</h2>
                 </a>
             </p>


### PR DESCRIPTION
The other guides link directly to their respective performance guides. This will bring VNV in line. Also makes the sidebar for Ammo Script Fixes functional.