### PR TITLE
Add Steam Deck/linux tips, while explicitly stating it is not officially supported

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -179,6 +179,9 @@
             <h2 class="install">Installation instructions:</h2>
             <ul>
                 <li><b>Main Files - The Mod Configuration Menu</b></li>
+                <ul>
+                    <li>On Steam Deck/linux, MO2's "manual" installation method is needed for this to install properly.</li>
+                </ul>
                 <li><b>Update File - MCM BugFix 2</b></li>
             </ul>
             Allows select mods to be configured via a single in-game menu.

--- a/intro.html
+++ b/intro.html
@@ -224,6 +224,9 @@
                     <li>
                         Mod Organizer 2 does <strong>not</strong> support ARM64 Windows. Vortex works, but is not supported by this guide.
                     </li>
+                    <li>
+                        Even though Steam Deck and linux are <strong>not</strong> officially supported by this guide, we do list a few tips to assist with Proton compatibility.
+                    </li>
                 </ul>
                 <li><a href="https://www.techpowerup.com/download/visual-c-redistributable-runtime-package-all-in-one/" target="_blank">VC++ Runtime Libraries</a>.</li>
                 <ul>

--- a/mo2.html
+++ b/mo2.html
@@ -244,6 +244,10 @@
             </p>
             <ol>
                 <li>Download <strong>Mod Organizer 2</strong> from <a href="https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.1rc2/Mod.Organizer-2.5.1rc2.7z" target="_blank">here</a>.</li>
+                <blockquote>
+                    Although Steam Deck and linux are not officially supported, users have reported success with <a href="https://github.com/rockerbacon/modorganizer2-linux-installer" target="_blank">this MO2 installer</a>, and using ProtonTricks to run the other tools in this guide.
+                    Note that with the Flatpak version of ProtonTricks, you may have to do some tweaking to get Nexus links to open in the mod manager, as described <a href="https://github.com/rockerbacon/modorganizer2-linux-installer/issues/317" target="_blank">here</a>.
+                </blockquote>
                 <li>Once the download has finished, right click the file and open its <strong>Properties</strong>.</li>
                 <li>In the properties window, if present, tick the <strong>Unblock</strong> checkbox at the bottom of <strong>General</strong> section.</li>
                 <blockquote>

--- a/mo2.html
+++ b/mo2.html
@@ -246,7 +246,7 @@
                 <li>Download <strong>Mod Organizer 2</strong> from <a href="https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.1rc2/Mod.Organizer-2.5.1rc2.7z" target="_blank">here</a>.</li>
                 <blockquote>
                     Although Steam Deck and linux are not officially supported, users have reported success with <a href="https://github.com/rockerbacon/modorganizer2-linux-installer" target="_blank">this MO2 installer</a>, and using ProtonTricks to run the other tools in this guide.
-                    Note that with the Flatpak version of ProtonTricks, you may have to do some tweaking to get Nexus links to open in the mod manager, as described <a href="https://github.com/rockerbacon/modorganizer2-linux-installer/issues/317" target="_blank">here</a>.
+                    Note that with the Flatpak version of ProtonTricks, you may have to modify <code>modorganizer2-nxm-handler.desktop</code> to get Nexus links to open in the mod manager, as described <a href="https://github.com/rockerbacon/modorganizer2-linux-installer/issues/317" target="_blank">here</a>.
                 </blockquote>
                 <li>Once the download has finished, right click the file and open its <strong>Properties</strong>.</li>
                 <li>In the properties window, if present, tick the <strong>Unblock</strong> checkbox at the bottom of <strong>General</strong> section.</li>

--- a/utilities.html
+++ b/utilities.html
@@ -436,6 +436,9 @@
                 <li><b>Main Files - UIO - User Interface Organizer</b></li>
             </ul>
             Automatically ensures that multiple HUD extensions work together, as well as fixing many bugs and improving performance.
+            <blockquote>
+            On Steam Deck/linux, a version of Proton higher than 8.0-5 (or version of UIO 2.2.0 or lower) is required for this to work.
+            </blockquote>
 
             <!-- KEYWORDS -->
             <p>

--- a/utilities.html
+++ b/utilities.html
@@ -210,16 +210,16 @@
                     <h2 id="bsaDecompressor">FNV BSA Decompressor</h2>
                 </a>
             </p>
-            <blockquote>On Steam Deck/linux, see <a href="https://www.nexusmods.com/newvegas/mods/65854?tab=posts" target="_blank">the pinned post on the mod's discussion page</a> to get this working.</blockquote>
             <h2 class="install">Installation instructions:</h2>
             <ol>
                 <li><b>Main Files - FNV BSA Decompressor</b> (Manual download).</li>
                 <li>Extract the archive into the <strong>Downloads</strong> folder</li>
                 <li>From the extracted archive, run <strong>FNV BSA Decompressor.exe</strong>.</li>
                 <li>The <strong>Fallout: New Vegas</strong> and <strong>Decompressed Archives</strong> paths should be filled by default (root folder and data folder respectively). If they aren't, close the program and re-run your game launcher to generate the required registry key.
-                    <blockquote>Epic Games version does not create any keys! You need to select the game folder manually!</blockquote>
+                    <blockquote>Epic Games and Proton versions do not create any keys! You need to select the game folder manually!</blockquote>
                 </li>
                 <li>Click <strong>Decompress</strong>, wait for the process the finish, then exit the program once finished.</li>
+                    <blockquote>On Steam Deck/linux, if you encounter an "insufficient free space on the drive" error, see <a href="https://www.nexusmods.com/newvegas/mods/65854?tab=posts" target="_blank">the pinned post on the mod's discussion page</a>.</blockquote>
                 <li>You can now delete files created in the step 2.</li>
             </ol>
             Decompresses BSA files to reduce loading times and stuttering. Can also fix certain sound effects not playing.

--- a/utilities.html
+++ b/utilities.html
@@ -210,6 +210,7 @@
                     <h2 id="bsaDecompressor">FNV BSA Decompressor</h2>
                 </a>
             </p>
+            <blockquote>On Steam Deck/linux, special tweaks are required to get this working. See <a href="https://www.nexusmods.com/newvegas/mods/65854?tab=posts" target="_blank">the pinned post on the mod's discussion page</a>.</blockquote>
             <h2 class="install">Installation instructions:</h2>
             <ol>
                 <li><b>Main Files - FNV BSA Decompressor</b> (Manual download).</li>

--- a/utilities.html
+++ b/utilities.html
@@ -434,11 +434,11 @@
             <h2 class="install">Installation instructions:</h2>
             <ul>
                 <li><b>Main Files - UIO - User Interface Organizer</b></li>
+                <ul>
+                    <li>On Steam Deck/linux, a version of Proton higher than 8.0-5 (or version of UIO 2.2.0 or lower) is required for this to work.</li>
+                </ul>
             </ul>
             Automatically ensures that multiple HUD extensions work together, as well as fixing many bugs and improving performance.
-            <blockquote>
-            On Steam Deck/linux, a version of Proton higher than 8.0-5 (or version of UIO 2.2.0 or lower) is required for this to work.
-            </blockquote>
 
             <!-- KEYWORDS -->
             <p>

--- a/utilities.html
+++ b/utilities.html
@@ -210,7 +210,7 @@
                     <h2 id="bsaDecompressor">FNV BSA Decompressor</h2>
                 </a>
             </p>
-            <blockquote>On Steam Deck/linux, special tweaks are required to get this working. See <a href="https://www.nexusmods.com/newvegas/mods/65854?tab=posts" target="_blank">the pinned post on the mod's discussion page</a>.</blockquote>
+            <blockquote>On Steam Deck/linux, see <a href="https://www.nexusmods.com/newvegas/mods/65854?tab=posts" target="_blank">the pinned post on the mod's discussion page</a> to get this working.</blockquote>
             <h2 class="install">Installation instructions:</h2>
             <ol>
                 <li><b>Main Files - FNV BSA Decompressor</b> (Manual download).</li>
@@ -435,7 +435,7 @@
             <ul>
                 <li><b>Main Files - UIO - User Interface Organizer</b></li>
                 <ul>
-                    <li>On Steam Deck/linux, a version of Proton higher than 8.0-5 (or version of UIO 2.2.0 or lower) is required for this to work.</li>
+                    <li>On Steam Deck/linux, a Proton version higher than 8.0-5 (or UIO version of 2.2.0 or lower) is required.</li>
                 </ul>
             </ul>
             Automatically ensures that multiple HUD extensions work together, as well as fixing many bugs and improving performance.


### PR DESCRIPTION
Feel free to reject this PR if you feel it makes the guide too cluttered, but I saw in discord that Steam Deck support was desired. This PR adds four simple pointers that _should_ be all that's needed to get all mods in the guide working (except maybe the "overhauls" section, which I did not test), while also stating (in two different locations) that Deck/linux are not officially supported.

Note that the pointers are just that - pointers. They're not step-by-step instructions like the rest of the guide, as I was worried about clutter. That is another reason why I've made the "not officially supported" part clear. However, these pointers should still save Deck/linux users a lot of debugging/researching time.

I tried my best to match the style of the rest of the guide, but I'd still consider it a "draft," and modifications are more than welcome.