### PR TITLE
optional navmesh patch context

### DIFF
--- a/bugfix.html
+++ b/bugfix.html
@@ -207,6 +207,8 @@
             </ul>
             This mod fixes and improves vanilla game pathfinding errors and will provide a better and more challenging experience with the AI.
 
+            If you do not plan on continuing to VNV Extended after finishing the base setup, you should install the YUP patch.
+
             <!-- Tweaks -->
             <p>
                 <a class="link" href="https://www.nexusmods.com/newvegas/mods/66347" target="_blank">


### PR DESCRIPTION
Hi,

I wanted to propose a PR that would help any potential hiccups for users following the guide. Currently if I follow the guide to a T and open the game during `Base Finish`, then I get a `NAVMESH error`. Which makes sense, because I am planning to continue on to VNV Extended, and the nexus page for the navmesh overhaul mentions to leave out the YUP patch if continuing to VNV Extended.

Feel free to request a change or something completely different. Or just deny the PR ha - I am probably talking out of class. Happy to be of help though, regardless. 