### PR TITLE
Removed Faster Main Menu under HUD

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -268,18 +268,6 @@
             </ul>
             Increases the render resolution of in-game screens (Pip-Boy, terminals, character creation menu) to match game's screen resolution.
 
-            <!-- Faster Menu -->
-            <p>
-                <a class="link" href="https://www.nexusmods.com/newvegas/mods/67811" target="_blank">
-                    <h2 id="fasterMenu">Faster Main Menu</h2>
-                </a>
-            </p>
-            <h2 class="install">Installation instructions:</h2>
-            <ul>
-                <li><b>Main Files - Faster Start Menu</b></li>
-            </ul>
-            Makes the game's main menu load faster.
-
             <!-- Menu Search -->
             <p>
                 <a class="link" href="https://www.nexusmods.com/newvegas/mods/81743" target="_blank">
@@ -357,9 +345,6 @@
             </li>
             <li>
                 <a href="#hdScreen">HD Screens</a>
-            </li>
-            <li>
-                <a href="#fasterMenu">Faster Main Menu</a>
             </li>
             <li>
                 <a href="#menuSearch">Menu Search</a>


### PR DESCRIPTION
It was already previously added under bug fixes. We can instead add a note stating to move the mod from `Bug Fixes` to `User Interface` separator or leave it under bug fixes.