### PR TITLE
fix: corrected Vigor URL

### DIFF
--- a/overhauls.html
+++ b/overhauls.html
@@ -169,13 +169,19 @@
 
             <!-- Vigor -->
             <p>
-                <a class="link" href="https://www.nexusmods.com/newvegas/mods/79358" target="_blank">
+                <a class="link" href="https://www.nexusmods.com/newvegas/mods/83576" target="_blank">
                     <h2 id="vigor">Vigor</h2>
                 </a>
             </p>
             <h2 class="install">Installation instructions:</h2>
             <ul>
-                <li><b>Main Files - Vigor - VNV Edit</b></li>
+                <li><b>Main Files - Vigor</b></li>
+                <li>
+                    <b><a href="https://www.nexusmods.com/newvegas/mods/79358" target="_blank">Viva New Vegas Resources</a></b>
+                    <ul>
+                        <li><b>Main Files - Vigor - VNV Edit</b></li>
+                    </ul>
+                </li>
                 <li>
                     <b><a href="https://www.nexusmods.com/newvegas/mods/84396" target="_blank">Simple Vigor Config</a></b>
                     <ul>


### PR DESCRIPTION
- Corrected Vigor URL
- Display main file to download from Vigor mod
- Display `Viva New Vegas Resources` title in the following step as the source for `Main Files - Vigor - VNV Edit`